### PR TITLE
Update DiscordFreeEmojisSplit48px.plugin.js

### DIFF
--- a/DiscordFreeEmojisSplit48px.plugin.js
+++ b/DiscordFreeEmojisSplit48px.plugin.js
@@ -159,7 +159,7 @@ function Start() {
     }
 
     function replaceEmoji(parseResult, emoji) {
-        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, emoji.url.split("?")[0] + "?size=48");
+        parseResult.content = parseResult.content.replace(`<${emoji.animated ? "a" : ""}:${emoji.originalName || emoji.name}:${emoji.id}>`, `[~](${emoji.url.split("?")[0]}?size=48)`);
     }
 
     parseHook = function() {


### PR DESCRIPTION
Added [~](emoji) to hide the link if you send text in the same message (?size=48)